### PR TITLE
adding hacky overriding log level

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -25,7 +25,10 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 		return nil, err
 	}
 
-	c.logger.log(ctx, LevelDebug, "Connect", start, err, logID)
+	// here, we're using the overriding log level to guarantee that it's included
+	// despite really being informational... this will allow us to mute other stuff
+	// we don't want to listen to
+	c.logger.log(ctx, LevelMustInclude, "Connect", start, err, logID)
 
 	return &connection{Conn: conn, logger: c.logger, id: id}, nil
 }

--- a/logger.go
+++ b/logger.go
@@ -21,6 +21,8 @@ const (
 	LevelInfo
 	// LevelError is used on actual driver error or when driver not implement some optional sql/driver interface.
 	LevelError
+	// LevelMustInclude is an overriding log level that must be included.
+	LevelMustInclude
 )
 
 // String implement Stringer to convert type Level to string.
@@ -35,6 +37,8 @@ func (l Level) String() string {
 		return "info"
 	case LevelError:
 		return "error"
+	case LevelMustInclude:
+		return "info"
 	default:
 		return fmt.Sprintf("(invalid level): %d", l)
 	}


### PR DESCRIPTION
This will allow us to do the following:
```
dsn := "username:passwd@tcp(mysqlserver:3306)/dbname?parseTime=true"
db, err := sql.Open("mysql", dsn) // db is *sql.DB
// handle err
loggerAdapter := zaplogadopter.New(...)
db = sqldblogger.OpenDriver(
   dsn,
   db.Driver(),
   loggerAdapter,
   sqldblogger.WithMinimumLevel(sqldblogger.LevelError), // will only log connections and errors
)
```